### PR TITLE
Popup CSS: Define only color settings and improve visibility.

### DIFF
--- a/ayu-dark.tmTheme
+++ b/ayu-dark.tmTheme
@@ -42,38 +42,27 @@
 				<key>lineHighlight</key>
 				<string>#151A1F</string>
 				<key>popupCss</key>
-				<string>html, body {
-  background-color: #14191F;
-  font-size: 12px;
-  color: #E6E1CF;
-  padding: 0;
-}
-body {
-  padding: 5px;
-}
-div {
-  padding-bottom: -3px;
-}
-b, strong {
-  font-weight: normal;
-}
-a {
-  color: rgba(54, 163, 217, .7);
-  line-height: 16px;
-}
-.type {
-  color: #F07178;
-}
-.name {
-  color: #E6B673;
-}
-.param {
-  color: #FFB454;
-}
-.current {
-  text-decoration: underline;
-}
-</string>
+				<string>
+					html, body {
+						background-color: #2D3640;
+						color: #E6E1CF;
+					}
+					a {
+						color: rgba(54, 163, 217, .7);
+					}
+					.type {
+						color: #F07178;
+					}
+					.name {
+						color: #E6B673;
+					}
+					.param {
+						color: #FFB454;
+					}
+					.current {
+						text-decoration: underline;
+					}
+				</string>
 				<key>selection</key>
 				<string>#253340</string>
 				<key>selectionBorder</key>

--- a/ayu-light.tmTheme
+++ b/ayu-light.tmTheme
@@ -42,38 +42,27 @@
 				<key>lineHighlight</key>
 				<string>#F2F2F2</string>
 				<key>popupCss</key>
-				<string>html, body {
-  background-color: #FFFFFF;
-  font-size: 12px;
-  color: #5C6773;
-  padding: 0;
-}
-body {
-  padding: 5px;
-}
-div {
-  padding-bottom: -3px;
-}
-b, strong {
-  font-weight: normal;
-}
-a {
-  color: rgba(65, 166, 217, .7);
-  line-height: 16px;
-}
-.type {
-  color: #F07178;
-}
-.name {
-  color: #CCA37A;
-}
-.param {
-  color: #F29718;
-}
-.current {
-  text-decoration: underline;
-}
-</string>
+				<string>
+					html, body {
+						background-color: #D9D8D7;
+						color: #5C6773;
+					}
+					a {
+						color: rgba(65, 166, 217, .7);
+					}
+					.type {
+						color: #F07178;
+					}
+					.name {
+						color: #CCA37A;
+					}
+					.param {
+						color: #F29718;
+					}
+					.current {
+						text-decoration: underline;
+					}
+				</string>
 				<key>selection</key>
 				<string>#F0EEE4</string>
 				<key>selectionBorder</key>

--- a/ayu-mirage.tmTheme
+++ b/ayu-mirage.tmTheme
@@ -42,38 +42,30 @@
 				<key>lineHighlight</key>
 				<string>#242B38</string>
 				<key>popupCss</key>
-				<string>html, body {
-  background-color: #272D38;
-  font-size: 12px;
-  color: #D9D7CE;
-  padding: 0;
-}
-body {
-  padding: 5px;
-}
-div {
-  padding-bottom: -3px;
-}
-b, strong {
-  font-weight: normal;
-}
-a {
-  color: rgba(92, 207, 230, .7);
-  line-height: 16px;
-}
-.type {
-  color: #F07178;
-}
-.name {
-  color: #FFC44C;
-}
-.param {
-  color: #FFD580;
-}
-.current {
-  text-decoration: underline;
-}
-</string>
+				<string>
+					html, body {
+						background-color: #3D4752;
+						color: #D9D7CE;
+					}
+					b, strong {
+						font-weight: normal;
+					}
+					a {
+						color: rgba(92, 207, 230, .7);
+					}
+					.type {
+						color: #F07178;
+					}
+					.name {
+						color: #FFC44C;
+					}
+					.param {
+						color: #FFD580;
+					}
+					.current {
+						text-decoration: underline;
+					}
+				</string>
 				<key>selection</key>
 				<string>#343F4C</string>
 				<key>selectionBorder</key>

--- a/src/templates/sublime.syntax.xml
+++ b/src/templates/sublime.syntax.xml
@@ -42,38 +42,27 @@
 				<key>lineHighlight</key>
 				<string>#"{syntax.line_hg.hex}"</string>
 				<key>popupCss</key>
-				<string>html, body {
-  background-color: #"{ui.panel.bg.hex}";
-  font-size: 12px;
-  color: #"{common.fg.hex}";
-  padding: 0;
-}
-body {
-  padding: 5px;
-}
-div {
-  padding-bottom: -3px;
-}
-b, strong {
-  font-weight: normal;
-}
-a {
-  color: rgba("{syntax.tag.rgb}", .7);
-  line-height: 16px;
-}
-.type {
-  color: #"{syntax.sup_var.hex}";
-}
-.name {
-  color: #"{syntax.es_spec.hex}";
-}
-.param {
-  color: #"{syntax.func.hex}";
-}
-.current {
-  text-decoration: underline;
-}
-</string>
+				<string>
+					html, body {
+						background-color: #"{syntax.gutterFg.hex}";
+						color: #"{common.fg.hex}";
+					}
+					a {
+						color: rgba("{syntax.tag.rgb}", .7);
+					}
+					.type {
+						color: #"{syntax.sup_var.hex}";
+					}
+					.name {
+						color: #"{syntax.es_spec.hex}";
+					}
+					.param {
+						color: #"{syntax.func.hex}";
+					}
+					.current {
+						text-decoration: underline;
+					}
+				</string>
 				<key>selection</key>
 				<string>#"{syntax.selection.hex}"</string>
 				<key>selectionBorder</key>

--- a/src/templates/sublime.syntax.yml
+++ b/src/templates/sublime.syntax.yml
@@ -32,23 +32,11 @@ settings:
     stackGuide: '#"{syntax.stack_guide.hex}"'
     popupCss: |
         html, body {
-          background-color: #"{ui.panel.bg.hex}";
-          font-size: 12px;
+          background-color: #"{syntax.gutterFg.hex}";
           color: #"{common.fg.hex}";
-          padding: 0;
-        }
-        body {
-          padding: 5px;
-        }
-        div {
-          padding-bottom: -3px;
-        }
-        b, strong {
-          font-weight: normal;
         }
         a {
           color: rgba("{syntax.tag.rgb}", .7);
-          line-height: 16px;
         }
         .type {
           color: #"{syntax.sup_var.hex}";


### PR DESCRIPTION
Hello guys,

I really like your theme/color scheme and thus decided to propose the following change to fix issue #102.

A color scheme is per name a definition of colors and thus should not manipulate any padding or font-size setting at all. This interferes with packages providing popups and makes it impossible to make a popup look good and equal with all color schemes.

The font-size of a popup should scale with the font-size of a view and thus must not be of fixed size.

The popups of AYU are not well visible. Especially a white popup on white background is completely useless. Thus I propose to change popup background to at least the gutter foreground or better find an own color.

Remarks: I didn't investigate how your infrastructure worked and thus manipulated all files by hand. So they may not be perfect.