### PR TITLE
Allow using the "default" Sublime Text UI font with `ui_font_default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Dark with `ui_separator` option on
 "ui_font_size_small":       true, // smaller UI font size(sidebar, statusbar etc)
 "ui_big_tabs":              true, // increased tab height
 "ui_fix_tab_labels":        true, // to fix tab labels if they look not right
-"ui_font_source_code_pro": true, // use [Source Code Pro](https://fonts.google.com/specimen/Source+Code+Pro) for UI
-"ui_wide_scrollbars":  true,  // wider scrollbars
-"ui_sidebar_highlight_row": true // to highlight whole row for current item in sidebar
+"ui_font_source_code_pro":  true, // use [Source Code Pro](https://fonts.google.com/specimen/Source+Code+Pro) for UI
+"ui_font_default":          true, // use Sublime Text's default UI font
+"ui_wide_scrollbars":       true, // wider scrollbars
+"ui_sidebar_highlight_row": true  // to highlight whole row for current item in sidebar
 ```
 
 # Installation

--- a/ayu-dark.sublime-theme
+++ b/ayu-dark.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "settings": ["highlight_modified_tabs"],
     "font.italic": true,
     "attributes": ["dirty"],
@@ -584,6 +594,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -620,6 +635,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -1020,6 +1040,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/ayu-dark2.sublime-theme
+++ b/ayu-dark2.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "fg": [81, 92, 102],
     "settings": ["ui_fix_tab_labels"],
     "shadow_color": [15, 20, 25, 0],
@@ -570,6 +580,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -606,6 +621,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -899,6 +919,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/ayu-light.sublime-theme
+++ b/ayu-light.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "settings": ["highlight_modified_tabs"],
     "font.italic": true,
     "attributes": ["dirty"],
@@ -584,6 +594,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -620,6 +635,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -1020,6 +1040,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/ayu-light2.sublime-theme
+++ b/ayu-light2.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "fg": [133, 136, 140],
     "settings": ["ui_fix_tab_labels"],
     "shadow_color": [250, 250, 250, 0],
@@ -570,6 +580,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -606,6 +621,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -899,6 +919,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/ayu-mirage.sublime-theme
+++ b/ayu-mirage.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "settings": ["highlight_modified_tabs"],
     "font.italic": true,
     "attributes": ["dirty"],
@@ -584,6 +594,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -620,6 +635,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -1020,6 +1040,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/ayu-mirage2.sublime-theme
+++ b/ayu-mirage2.sublime-theme
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "fg": [115, 134, 153],
     "settings": ["ui_fix_tab_labels"],
     "shadow_color": [33, 39, 51, 0],
@@ -570,6 +580,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -606,6 +621,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -899,6 +919,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/src/templates/sublime.ui.json
+++ b/src/templates/sublime.ui.json
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "settings": ["highlight_modified_tabs"],
     "font.italic": true,
     "attributes": ["dirty"],
@@ -584,6 +594,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -620,6 +635,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -1020,6 +1040,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels

--- a/src/templates/sublime2.ui.json
+++ b/src/templates/sublime2.ui.json
@@ -140,6 +140,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "tool_tip_label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   /* @OVERLAY PANELS
   * Overlay panels setting and behavioring
@@ -381,6 +386,11 @@
   },
   {
     "class": "tab_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
+  {
+    "class": "tab_label",
     "fg": ["{ui.fg.rgb}"],
     "settings": ["ui_fix_tab_labels"],
     "shadow_color": ["{common.bg.rgb}", 0],
@@ -570,6 +580,11 @@
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
   },
+  {
+    "class": "sidebar_heading",
+    "settings": ["ui_font_default"],
+    "font.face": ""
+  },
 
   {
     "class": "tree_row",
@@ -606,6 +621,11 @@
     "class": "sidebar_label",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "sidebar_label",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   {
@@ -899,6 +919,11 @@
     "class": "label_control",
     "settings": ["ui_font_source_code_pro"],
     "font.face": "Source Code Pro"
+  },
+  {
+    "class": "label_control",
+    "settings": ["ui_font_default"],
+    "font.face": ""
   },
 
   // Status bar labels


### PR DESCRIPTION
fixes #127

<img width="1396" alt="screen shot 2017-07-13 at 7 58 23 pm" src="https://user-images.githubusercontent.com/282113/28196461-acaad8f6-6805-11e7-8042-52730308eedb.png">
