### PR TITLE
Add type fix for source.zig storage.type

### DIFF
--- a/ayu-dark.sublime-color-scheme
+++ b/ayu-dark.sublime-color-scheme
@@ -126,7 +126,7 @@
 		},
 		{
 			"name": "Types fixes",
-			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type",
+			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type, source.zig storage.type",
 			"foreground": "#59c2ff"
 		},
 		{

--- a/ayu-light.sublime-color-scheme
+++ b/ayu-light.sublime-color-scheme
@@ -126,7 +126,7 @@
 		},
 		{
 			"name": "Types fixes",
-			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type",
+			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type, source.zig storage.type",
 			"foreground": "#22a4e6"
 		},
 		{

--- a/ayu-mirage.sublime-color-scheme
+++ b/ayu-mirage.sublime-color-scheme
@@ -126,7 +126,7 @@
 		},
 		{
 			"name": "Types fixes",
-			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type",
+			"scope": "source.java storage.type, source.haskell storage.type, source.c storage.type, source.zig storage.type",
 			"foreground": "#73d0ff"
 		},
 		{

--- a/src/templates/syntax.ts
+++ b/src/templates/syntax.ts
@@ -176,7 +176,7 @@ export default (scheme: Scheme) => ({
     // Types
     {
       name: 'Types fixes',
-      scope: 'source.java storage.type, source.haskell storage.type, source.c storage.type',
+      scope: 'source.java storage.type, source.haskell storage.type, source.c storage.type, source.zig storage.type',
       foreground: scheme.syntax.entity.hex()
     },
     {


### PR DESCRIPTION
A small fix to better support zig syntax.

I have to note that I manually edited the `sublime-color-scheme` files because I was not able to make the `build.ts` script run on my end. I was getting the following errors:

```
error TS6059: File '<PATH>/ayu/test/TSX.tsx' is not under 'rootDir' '<PATH>/ayu/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in 'tsconfig.json'

error TS6059: File '<PATH>/ayu/test/TypeScript.ts' is not under 'rootDir' '<PATH>/ayu/src'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '**/*' in 'tsconfig.json'

test/TypeScript.ts:16:53 - error TS4020: 'extends' clause of exported class 'Bot' has or is using private name 'OtherClass'.

16 export abstract class Bot<BotMessage = any> extends OtherClass {
                                                       ~~~~~~~~~~


Found 3 errors in the same file, starting at: test/TypeScript.ts:16
```

And even after I deleted the `test` directory, it complained that it can't find the module `'fs'` and some other dependencies, so I just gave up. I apologize but I'm completely new to TS and I didn't find a guide in the README or a CONTRIB file.