### PR TITLE
Add Vim and Gnome terminal / Gogh project

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ and install manually [latest supported version](https://github.com/dempfi/ayu/re
 - `ayu` for VSCode: https://github.com/teabyii/vscode-ayu
 - `ayu` for XCode: https://github.com/vburojevic/ayu-xcode-theme
 - `ayu` for [Kakoune](https://github.com/mawww/kakoune): https://github.com/icantjuddle/ayu-kak
+- `ayu` for Gnome terminal/iTerm: select ayu theme from https://github.com/Gogh-Co/Gogh/
+- `ayu` for Vim: https://github.com/ayu-theme/ayu-vim (also vim-airline via `:AirlineThemes ayu`)  
 
 <div align="right"><sup>
   made with ❤️ by <a href="https://github.com/dempfi">@dempfi</a>


### PR DESCRIPTION
There's a good couple of resources for Ayu for Vim, Vim-airline and Gnome terminal but its hard to find them, so I thought it would be good to add them to the README.

The one thing that's missing (at least my setup of VS Code + Nvim combined) is colours for the VS Code terminal such as https://glitchbone.github.io/vscode-base16-term/. Unfortunately that project doesn't seem to be maintained any more so can't add any new themes.