### PR TITLE
Fix bug where settings property is provided an obj instead of an array

### DIFF
--- a/ayu-dark.sublime-theme
+++ b/ayu-dark.sublime-theme
@@ -461,9 +461,9 @@
 	},
 	{
 		"class": "sheet_contents",
-		"settings": {
-			"inactive_sheet_dimming": true
-		},
+		"settings": [
+			"inactive_sheet_dimming"
+		],
 		"attributes": [
 			"!highlighted"
 		],

--- a/ayu-light.sublime-theme
+++ b/ayu-light.sublime-theme
@@ -461,9 +461,9 @@
 	},
 	{
 		"class": "sheet_contents",
-		"settings": {
-			"inactive_sheet_dimming": true
-		},
+		"settings": [
+			"inactive_sheet_dimming"
+		],
 		"attributes": [
 			"!highlighted"
 		],

--- a/ayu-mirage.sublime-theme
+++ b/ayu-mirage.sublime-theme
@@ -461,9 +461,9 @@
 	},
 	{
 		"class": "sheet_contents",
-		"settings": {
-			"inactive_sheet_dimming": true
-		},
+		"settings": [
+			"inactive_sheet_dimming"
+		],
 		"attributes": [
 			"!highlighted"
 		],

--- a/src/templates/ui.ts
+++ b/src/templates/ui.ts
@@ -315,7 +315,7 @@ export default (scheme: Scheme, kind: string) => [
   },
   {
     "class": "sheet_contents",
-    "settings": { "inactive_sheet_dimming": true, },
+    "settings": ["inactive_sheet_dimming"],
     "attributes": ["!highlighted"],
     "background_modifier": `blend(${scheme.ui.bg.hex()} 0%)`
   },


### PR DESCRIPTION
There is a bug where the settings property https://github.com/dempfi/ayu/issues/281:

```
Errors parsing theme:
  "settings" must be a vector in Packages/ayu/ayu-light.sublime-theme:464:15
```

This change keeps the intended value in the settings, but fixes the error message and therefore actually applies the intended styling.